### PR TITLE
Add special case to walk around TYPE_CHECKING blocks

### DIFF
--- a/pytest_arch/collect.py
+++ b/pytest_arch/collect.py
@@ -20,7 +20,7 @@ def collect_imports_from_path(path, package):
     for py_file in Path(path).glob("**/*.py"):
         module_name = path_to_module(py_file, path, package)
         tree = ast.parse(py_file.read_bytes())
-        import_it = extract_imports_ast(tree, module_name)
+        import_it = extract_imports_ast(walk(tree), module_name)
         yield module_name, set(import_it)
 
 
@@ -62,8 +62,8 @@ def path_to_module(module_path: Path, base_path: Path, package=None) -> str:
     return re.sub(r"\.+", ".", module)
 
 
-def extract_imports_ast(tree, package: str, resolve=True) -> Iterable[str]:
-    for node in walk(tree):
+def extract_imports_ast(nodes: Iterable[ast.AST], package: str, resolve=True) -> Iterable[str]:
+    for node in nodes:
         if isinstance(node, ast.Import):
             for alias in node.names:
                 yield alias.name
@@ -77,7 +77,7 @@ def extract_imports_ast(tree, package: str, resolve=True) -> Iterable[str]:
 
 
 # from ast:
-def walk(node):
+def walk(node) -> Iterable[ast.AST]:
     todo = deque([node])
     while todo:
         node = todo.popleft()

--- a/pytest_arch/rule.py
+++ b/pytest_arch/rule.py
@@ -118,10 +118,10 @@ class RuleConstraints:
         self.ignored.append(pattern)
         return self
 
-    def check(self, package: str | ModuleType):
+    def check(self, package: str | ModuleType, *, type_checking=True):
         """Check the rule against a package or module."""
         rule_name = self.rule.name
-        all_imports = collect_imports(package)
+        all_imports = collect_imports(package, type_checking=type_checking)
         match_criteria = self.targets.match_criteria
         exclude_criteria = self.targets.exclude_criteria
 

--- a/pytest_arch/rule.py
+++ b/pytest_arch/rule.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
 from fnmatch import fnmatch
+from functools import partial
 from types import ModuleType
 
 from pytest_check import check
 
-from pytest_arch.collect import collect_imports
+from pytest_arch.collect import collect_imports, walk
 
 
 def archrule(name: str, comment: str | None = None) -> Rule:
@@ -121,7 +122,7 @@ class RuleConstraints:
     def check(self, package: str | ModuleType, *, type_checking=True):
         """Check the rule against a package or module."""
         rule_name = self.rule.name
-        all_imports = collect_imports(package, type_checking=type_checking)
+        all_imports = collect_imports(package, partial(walk, type_checking=type_checking))
         match_criteria = self.targets.match_criteria
         exclude_criteria = self.targets.exclude_criteria
 

--- a/tests/test_ast.py
+++ b/tests/test_ast.py
@@ -32,7 +32,7 @@ def test_skip_type_checking_marker():
     )
 
     root = ast.parse(code, "test_parse.py")
-    imports = list(extract_imports_ast(walk(root), ""))
+    imports = list(extract_imports_ast(walk(root, type_checking=False), ""))
 
     # Should this be os.path?
     assert "datetime" not in imports
@@ -50,7 +50,7 @@ def test_skip_typing_dot_type_checking_marker():
     )
 
     root = ast.parse(code, "test_parse.py")
-    imports = list(extract_imports_ast(walk(root), ""))
+    imports = list(extract_imports_ast(walk(root, type_checking=False), ""))
 
     # Should this be os.path?
     assert "datetime" not in imports

--- a/tests/test_ast.py
+++ b/tests/test_ast.py
@@ -4,11 +4,12 @@ from textwrap import dedent
 from pytest_arch.collect import extract_imports_ast
 
 
-def test_parse():
+def test_parse_imports():
     code = dedent(
         """\
         import sys
-        from datetime import datetime
+        if True:
+            from datetime import datetime
         """
     )
 
@@ -17,6 +18,42 @@ def test_parse():
 
     # Should this be os.path?
     assert "datetime" in imports
+    assert "sys" in imports
+
+
+def test_skip_type_checking_marker():
+    code = dedent(
+        """\
+        import sys
+        from typing import TYPE_CHECKING
+        if TYPE_CHECKING:
+            from datetime import datetime
+        """
+    )
+
+    root = ast.parse(code, "test_parse.py")
+    imports = list(extract_imports_ast(root, ""))
+
+    # Should this be os.path?
+    assert "datetime" not in imports
+    assert "sys" in imports
+
+
+def test_skip_typing_dot_type_checking_marker():
+    code = dedent(
+        """\
+        import sys
+        import typing
+        if typing.TYPE_CHECKING:
+            from datetime import datetime
+        """
+    )
+
+    root = ast.parse(code, "test_parse.py")
+    imports = list(extract_imports_ast(root, ""))
+
+    # Should this be os.path?
+    assert "datetime" not in imports
     assert "sys" in imports
 
 

--- a/tests/test_ast.py
+++ b/tests/test_ast.py
@@ -1,7 +1,7 @@
 import ast
 from textwrap import dedent
 
-from pytest_arch.collect import extract_imports_ast
+from pytest_arch.collect import extract_imports_ast, walk
 
 
 def test_parse_imports():
@@ -14,7 +14,7 @@ def test_parse_imports():
     )
 
     root = ast.parse(code, "test_parse.py")
-    imports = list(extract_imports_ast(root, ""))
+    imports = list(extract_imports_ast(walk(root), ""))
 
     # Should this be os.path?
     assert "datetime" in imports
@@ -32,7 +32,7 @@ def test_skip_type_checking_marker():
     )
 
     root = ast.parse(code, "test_parse.py")
-    imports = list(extract_imports_ast(root, ""))
+    imports = list(extract_imports_ast(walk(root), ""))
 
     # Should this be os.path?
     assert "datetime" not in imports
@@ -50,7 +50,7 @@ def test_skip_typing_dot_type_checking_marker():
     )
 
     root = ast.parse(code, "test_parse.py")
-    imports = list(extract_imports_ast(root, ""))
+    imports = list(extract_imports_ast(walk(root), ""))
 
     # Should this be os.path?
     assert "datetime" not in imports
@@ -90,7 +90,7 @@ def test_parse_relative_imports(create_testset, monkeypatch):
 
     monkeypatch.syspath_prepend(path)
     root = ast.parse(code)
-    imports = set(extract_imports_ast(root, "pkgA.subpkg1.subpkg1a"))
+    imports = set(extract_imports_ast(walk(root), "pkgA.subpkg1.subpkg1a"))
 
     assert imports == {
         "datetime",

--- a/tests/test_collect.py
+++ b/tests/test_collect.py
@@ -6,6 +6,7 @@ from pytest_arch.collect import (
     path_to_module,
     resolve_module_or_object_by_path,
     resolve_module_or_object_by_spec,
+    walk,
 )
 
 
@@ -91,7 +92,7 @@ def test_collect_pkg(create_testset, monkeypatch):
         ("abcz/moduleC.py", ""),
     )
     monkeypatch.syspath_prepend(str(path))
-    data = collect_imports("abcz")
+    data = collect_imports("abcz", walker=walk)
     assert "abcz.moduleC" in data["abcz.moduleA"]["transitive"]
 
 


### PR DESCRIPTION
Type checks can introduce cyclic dependencies, or dependencies in places where you do not have them at runtime.

This PR introduces a custom tree walker that walks around `TYPE_CHECKING` clauses.

I think we should make this configurable, though.